### PR TITLE
Fixed typo in uboot-env.bin build rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ u-boot/tools/env/fw_setenv:
 	$(MAKE) CROSS_COMPILE= -C u-boot imx8mm_venice_defconfig envtools
 	ln -sf fw_printenv u-boot/tools/env/fw_setenv
 
-u-boot-env.bin: venice/fw_env.config venice/venice.env
+uboot-env.bin: venice/fw_env.config venice/venice.env
 	# start with uboot env at end of 4MiB (per venice/fw_env.config)
 	truncate -s 4M firmware.img
 	u-boot/tools/env/fw_setenv --lock venice/. --config venice/fw_env.config --script venice/venice.env


### PR DESCRIPTION
Reverted a typo in the Makefile that broke subsequent build dependencies, which required `uboot-env.bin` instead of `u-boot-env.bin`.

Context:

https://github.com/Gateworks/bsp-venice/commit/003bdff27a5c786ef8b9d0132f944799fd191e4a#commitcomment-146640006