### PR TITLE
Add -p flag to e2fsck for filesystem check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ ubuntu-image: linux-venice.tar.xz mkimage_jtag venice-imx8mm-flash.bin uboot-env
 		echo "$(UBUNTU_FS): avail:$${mbytesavail}M/$${mbytestotal}M needed:$${mbytesneeded}M";\
 		if [ $$mbytesneeded -ge $$mbytesavail ]; then \
 			echo "resizing $${mbytestotal}M to $${resizeto}M..."; \
-			e2fsck -f $(UBUNTU_FS); \
+			e2fsck -fp $(UBUNTU_FS); \
 			resize2fs $(UBUNTU_FS) $${resizeto}M; \
 		fi; \
 	)


### PR DESCRIPTION
Allow e2fsck to autofix any errors it can. Currently e2fsck runs in check mode, but doesn't fix any issues. With our customized kernel our builds are failing due to the lack of an interactive terminal to fix the (apparently alignment?) issues that do arise. -p should always restrict to only automatically fixing those issues where it can safely do so, so it is always safe to enable in an automated environment like the BSP build. Without enabling -n, -p, or -y, e2fsck is effectively a no-op in this automated environment and, worse, can kill the build process.